### PR TITLE
Refactor health plugin and update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
+name = "wildmatch"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
+
+[[package]]
 name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4750,4 +4756,5 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "wildmatch",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -213,12 +213,6 @@ dependencies = [
  "syn",
  "which",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -476,23 +470,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-libproc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb90051930c9a0f09e585762152048e23ac74d20c10590ef7cf01c0343c3046"
-dependencies = [
- "darwin-libproc-sys",
- "libc",
- "memchr",
-]
-
-[[package]]
-name = "darwin-libproc-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cebb5bde66eecdd30ddc4b9cd208238b15db4982ccc72db59d699ea10867c1"
-dependencies = [
- "libc",
-]
+version = "0.2.0"
 
 [[package]]
 name = "data-encoding"
@@ -523,13 +501,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "derive_more-impl 1.0.0",
 ]
 
 [[package]]
@@ -538,7 +514,18 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1409,7 +1396,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -1568,7 +1555,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "libc",
  "redox_syscall",
 ]
@@ -1804,12 +1791,13 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1953,7 +1941,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2288,9 +2276,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platforms"
-version = "2.0.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
+checksum = "0b02ffed1bc8c2234bb6f8e760e34613776c5102a041f25330b869a78153a68c"
 
 [[package]]
 name = "portable-atomic"
@@ -2385,20 +2373,20 @@ dependencies = [
 
 [[package]]
 name = "psutil"
-version = "3.3.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e617cc9058daa5e1fe5a0d23ed745773a5ee354111dad1ec0235b0cc16b6730"
+checksum = "e544b9b9436e4bc389214d2a0a7c36a92eef2fd7693a8933b364f1ca21906d87"
 dependencies = [
  "cfg-if",
  "darwin-libproc",
- "derive_more 0.99.20",
+ "derive_more 1.0.0",
  "glob",
  "mach2",
  "nix",
  "num_cpus",
  "once_cell",
  "platforms",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "unescape",
 ]
 
@@ -2539,7 +2527,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
 ]
 
 [[package]]
@@ -2710,7 +2698,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2723,7 +2711,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2821,7 +2809,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2844,7 +2832,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "cssparser",
  "derive_more 2.0.1",
  "fxhash",
@@ -3146,7 +3134,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.3",
+ "bitflags",
  "byteorder",
  "bytes",
  "crc",
@@ -3189,7 +3177,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.3",
+ "bitflags",
  "byteorder",
  "crc",
  "dotenvy",
@@ -3356,7 +3344,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3683,7 +3671,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -4468,7 +4456,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
 ]
 
 [[package]]
@@ -4607,7 +4595,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "psutil",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "rink-core",
  "scraper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,28 +92,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,53 +153,6 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1021,7 +952,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1058,12 +989,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1079,7 +1004,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1236,12 +1161,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,7 +1190,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1293,19 +1211,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
  "tower-service",
 ]
 
@@ -1484,22 +1389,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1786,12 +1681,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -2104,42 +1993,53 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.27.0"
+name = "opentelemetry-http"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
- "futures-core",
+ "bytes",
  "http",
  "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.69",
- "tokio",
- "tonic",
+ "reqwest",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2148,56 +2048,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
+name = "opentelemetry-resource-detectors"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+checksum = "0a44e076f07fa3d76e741991f4f7d3ecbac0eed8521ced491fbdf8db77d024cf"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.27.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8a298402aa5c260be90d10dc54b5a7d4e1025c354848f8e2c976d761351049"
+checksum = "447191061af41c3943e082ea359ab8b64ff27d6d34d30d327df309ddef1eef6f"
 dependencies = [
- "async-trait",
  "chrono",
- "futures-util",
  "opentelemetry",
  "opentelemetry_sdk",
- "ordered-float",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2687,7 +2580,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2709,7 +2604,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2747,7 +2642,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "chrono-tz",
- "indexmap 2.11.0",
+ "indexmap",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -3185,9 +3080,9 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown",
  "hashlink",
- "indexmap 2.11.0",
+ "indexmap",
  "log",
  "memchr",
  "native-tls",
@@ -3732,7 +3627,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3748,49 +3643,20 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum",
  "base64",
  "bytes",
- "h2",
  "http",
  "http-body",
  "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2 0.5.10",
- "tokio",
  "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3824,7 +3690,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3887,16 +3753,16 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4736,6 +4602,7 @@ dependencies = [
  "num-format",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-resource-detectors",
  "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["zeta"]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 resolver = "3"
-members = ["zeta"]
+members = [ "zeta"]
+
+[patch.crates-io]
+darwin-libproc = { path = "stub/darwin-libproc" }
 
 [profile.release]
 lto = "fat"

--- a/stub/darwin-libproc/Cargo.toml
+++ b/stub/darwin-libproc/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "darwin-libproc"
+version = "0.2.0"
+edition = "2024"
+
+[dependencies]

--- a/stub/darwin-libproc/src/lib.rs
+++ b/stub/darwin-libproc/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/zeta/Cargo.toml
+++ b/zeta/Cargo.toml
@@ -59,3 +59,6 @@ pedantic = "warn"
 nursery = "warn"
 cargo = "allow"
 doc_markdown = "allow"
+
+[dev-dependencies]
+wildmatch = "2.4.0"

--- a/zeta/Cargo.toml
+++ b/zeta/Cargo.toml
@@ -27,8 +27,8 @@ opentelemetry-resource-detectors = "0.9.0"
 opentelemetry-semantic-conventions = "0.30.0"
 opentelemetry-stdout = "0.30.0"
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
-psutil = "3.3.0"
-rand = "0.8.5"
+psutil = "5.4.0"
+rand = "0.9.2"
 reqwest = { version = "0.12.15", features = ["json"] }
 rink-core = { version = "0.8.0", features = ["bundle-files"] }
 scraper = "0.24.0"
@@ -36,7 +36,7 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.140"
 serde_path_to_error = "0.1.17"
 shlex = "1.3.0"
-sqlx = { version = "0.8.2", default-features = false, features = ["migrate", "macros", "postgres", "runtime-tokio-native-tls", "time"] }
+sqlx = { version = "0.8.6", default-features = false, features = ["migrate", "macros", "postgres", "runtime-tokio-native-tls", "time"] }
 thiserror = "2.0"
 time = { version = "0.3.43", features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.41.1", features = ["full"] }

--- a/zeta/Cargo.toml
+++ b/zeta/Cargo.toml
@@ -21,11 +21,12 @@ humantime-serde = "1.1.1"
 irc = { version = "1.0.0", default-features = false, features = ["serde", "tls-native", "ctcp", "channel-lists"] }
 miette = { version = "7.2.0", features = ["fancy"] }
 num-format = "0.4.4"
-opentelemetry = "0.27.0"
-opentelemetry-otlp = "0.27.0"
-opentelemetry-semantic-conventions = "0.27.0"
-opentelemetry-stdout = "0.27.0"
-opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio"] }
+opentelemetry = "0.30.0"
+opentelemetry-otlp = "0.30.0"
+opentelemetry-resource-detectors = "0.9.0"
+opentelemetry-semantic-conventions = "0.30.0"
+opentelemetry-stdout = "0.30.0"
+opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
 psutil = "3.3.0"
 rand = "0.8.5"
 reqwest = { version = "0.12.15", features = ["json"] }
@@ -40,7 +41,7 @@ thiserror = "2.0"
 time = { version = "0.3.43", features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.41.1", features = ["full"] }
 tracing = "0.1.40"
-tracing-opentelemetry = { version = "0.28.0", features = ["thiserror"] }
+tracing-opentelemetry = { version = "0.31.0", features = ["thiserror"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 url = "2.5.4"
 

--- a/zeta/src/cli.rs
+++ b/zeta/src/cli.rs
@@ -1,41 +1,6 @@
-use std::{fmt, path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 
 use argh::FromArgs;
-
-/// The output format of logging messages to stdout.
-#[derive(Debug, Clone, Default)]
-pub enum Format {
-    /// Output events as JSON.
-    Json,
-    /// Output events in an excessively human-readable format.
-    Pretty,
-    /// Output events in a human-readable format.
-    #[default]
-    Compact,
-}
-
-impl fmt::Display for Format {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Json => write!(f, "json"),
-            Self::Pretty => write!(f, "pretty"),
-            Self::Compact => write!(f, "compact"),
-        }
-    }
-}
-
-impl FromStr for Format {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "json" => Ok(Self::Json),
-            "pretty" => Ok(Self::Pretty),
-            "compact" => Ok(Self::Compact),
-            _ => Err("unsupported format, must be one of json, pretty, compact, full".to_string()),
-        }
-    }
-}
 
 /// Masked mails server
 #[derive(FromArgs, Debug)]
@@ -43,7 +8,4 @@ pub struct Opts {
     /// the path to the config file
     #[argh(option, short = 'c', default = r#"PathBuf::from("config.toml")"#)]
     pub config_path: PathBuf,
-    /// logging output format to stdout
-    #[argh(option, default = "Format::default()")]
-    pub format: Format,
 }

--- a/zeta/src/main.rs
+++ b/zeta/src/main.rs
@@ -12,6 +12,7 @@ mod tracing;
 
 use zeta::database;
 use zeta::{Config, Zeta};
+pub use zeta::{Error, config};
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
@@ -22,7 +23,7 @@ async fn main() -> miette::Result<()> {
         .extract()
         .into_diagnostic()?;
 
-    tracing::init(&opts.format, &config.tracing)?;
+    tracing::try_init(&config.tracing)?;
 
     debug!("connecting to database");
     let db = database::connect(config.database.url.as_str(), &config.database).await?;

--- a/zeta/src/plugin/health.rs
+++ b/zeta/src/plugin/health.rs
@@ -12,6 +12,22 @@ use super::{Author, Name, Plugin, Version};
 
 pub struct Health;
 
+/// Process telemetry snapshot.
+pub struct Snapshot {
+    /// The RSS memory usage, as MiB.
+    pub rss_mib: f64,
+    /// The VMS memory usage, as MiB.
+    pub vms_mib: f64,
+    /// The shared memory usage, as MiB.
+    pub shared_mib: f64,
+    /// The number of tasks currently scheduled in the runtime's global queue.
+    pub global_queue_depth: usize,
+    /// The current number of alive tasks in the runtime.
+    pub num_alive_tasks: usize,
+    /// The number of worker threads used by the runtime.
+    pub num_workers: usize,
+}
+
 #[async_trait]
 impl Plugin for Health {
     fn new() -> Health {
@@ -33,39 +49,59 @@ impl Plugin for Health {
     async fn handle_message(&self, message: &Message, client: &Client) -> Result<(), ZetaError> {
         if let Command::PRIVMSG(ref channel, ref message) = message.command
             && message.starts_with(".health")
+            && let Some(snapshot) = Snapshot::capture()
         {
-            client.send_privmsg(channel, self.to_string())?;
+            client.send_privmsg(channel, format!("\x0310> Health:\x0f {snapshot}"))?;
         }
 
         Ok(())
     }
 }
 
-impl Display for Health {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(fmt, "\x0310>\x02\x03 Health:\x02\x0310 ")?;
-
+impl Snapshot {
+    #[allow(clippy::cast_precision_loss)]
+    pub fn capture() -> Option<Snapshot> {
         if let Ok(proc) = Process::current()
             && let Ok(memory) = proc.memory_info()
         {
+            // Capture memory information
             let rss_mib = memory.rss() as f64 / 1024. / 1024.;
             let vms_mib = memory.vms() as f64 / 1024. / 1024.;
             let shared_mib = memory.shared() as f64 / 1024. / 1024.;
 
-            write!(
-                fmt,
-                "Memory usage:\x0f {rss_mib:.2} MiB\x0310 (VMS:\x0f {vms_mib:.2} MiB\x0310 Shared:\x0f {shared_mib:.2} MiB\x0310)",
-            )?;
+            // Capture tokio runtime information
+            let metrics = Handle::current().metrics();
+            let num_workers = metrics.num_workers();
+            let num_alive_tasks = metrics.num_alive_tasks();
+            let global_queue_depth = metrics.global_queue_depth();
+
+            return Some(Snapshot {
+                rss_mib,
+                vms_mib,
+                shared_mib,
+                global_queue_depth,
+                num_alive_tasks,
+                num_workers,
+            });
         }
 
-        let metrics = Handle::current().metrics();
-        let num_workers = metrics.num_workers();
-        let num_alive_tasks = metrics.num_alive_tasks();
-        let global_queue_depth = metrics.global_queue_depth();
+        None
+    }
+}
 
-        write!(fmt, "Workers:\x0f {num_workers}\x0310 ")?;
-        write!(fmt, "Tasks:\x0f {num_alive_tasks}\x0310 ")?;
-        write!(fmt, "(\x0f{global_queue_depth}\x0310 scheduled) ")?;
+impl Display for Snapshot {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let rss_mib = self.rss_mib;
+        let vms_mib = self.vms_mib;
+        let shared_mib = self.shared_mib;
+
+        write!(fmt, "Memory usage:\x0f {rss_mib:.2} MiB\x0310 ")?;
+        write!(fmt, "(VMS:\x0f {vms_mib:.2} MiB\x0310 ")?;
+        write!(fmt, "Shared:\x0f {shared_mib:.2} MiB\x0310) ")?;
+
+        write!(fmt, "Workers:\x0f {}\x0310 ", self.num_workers)?;
+        write!(fmt, "Tasks:\x0f {}\x0310 ", self.num_alive_tasks)?;
+        write!(fmt, "(\x0f{}\x0310 scheduled)", self.global_queue_depth)?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR stubs out the `darwin-libproc` crate which may break macOS builds, but it fixes the conflict in `psutil` and `sqlx`.

It also refactors the health plugin and adds a test case.

Pretty output logging is no longer supported. A tool like [hl](https://github.com/pamburus/hl) is recommended instead.