### PR TITLE
Replace name, author, version fns with metadata fn

### DIFF
--- a/zeta-plugin/src/lib.rs
+++ b/zeta-plugin/src/lib.rs
@@ -6,4 +6,10 @@ mod types;
 
 pub use error::Error;
 pub use plugin::Plugin;
-pub use types::{Author, Name, Version};
+pub use types::{Author, Metadata, Name};
+
+pub mod prelude {
+    pub use async_trait::async_trait;
+
+    pub use super::{Author, Metadata, Name, Plugin};
+}

--- a/zeta-plugin/src/plugin.rs
+++ b/zeta-plugin/src/plugin.rs
@@ -2,9 +2,46 @@ use async_trait::async_trait;
 use irc::client::Client;
 use irc::proto::Message;
 
-use crate::{Author, Error, Name, Version};
+use crate::{Error, Metadata};
 
 /// The base trait that all plugins must implement.
+///
+///# Examples
+///
+/// ```
+/// use irc::client::Client;
+/// use irc::proto::{Command, Message};
+/// use zeta_plugin::{Error, prelude::*};
+///
+/// struct MyPlugin;
+///
+///#[async_trait]
+/// impl Plugin for MyPlugin {
+///     fn new(_: &()) -> MyPlugin {
+///         MyPlugin
+///     }
+///
+///     fn metadata() -> Metadata {
+///         Metadata {
+///             name: "my_plugin".into(),
+///             authors: vec!["John Doe <john.doe@example.com>".into()]
+///        }
+///     }
+///
+///     async fn handle_message(
+///         &self,
+///         _ctx: &(),
+///         client: &Client,
+///         message: &Message,
+///     ) -> Result<(), Error> {
+///         if let Command::PRIVMSG(ref target, _) = message.command {
+///             let nick = message.source_nickname().unwrap_or("unknown");
+///             client.send_privmsg(target, format!("hello, {nick}!"))?;
+///         }
+///         Ok(())
+///     }
+/// }
+/// ```
 #[async_trait]
 pub trait Plugin<C = ()>: Send + Sync {
     /// The constructor for a new plugin.
@@ -12,18 +49,8 @@ pub trait Plugin<C = ()>: Send + Sync {
     where
         Self: Sized;
 
-    /// Returns the name of the plugin.
-    fn name() -> Name
-    where
-        Self: Sized;
-
-    /// Returns the author of the plugin.
-    fn author() -> Author
-    where
-        Self: Sized;
-
-    /// Returns the version of the plugin.
-    fn version() -> Version
+    /// Metadata describing the plugin and its authorship.
+    fn metadata() -> Metadata
     where
         Self: Sized;
 

--- a/zeta-plugin/src/types.rs
+++ b/zeta-plugin/src/types.rs
@@ -45,6 +45,12 @@ macro_rules! metadata_type {
     };
 }
 
+pub struct Metadata {
+    /// Name of the plugin.
+    pub name: Name,
+    /// List of authors that maintains or contributes to the plugin.
+    pub authors: Vec<Author>,
+}
+
 metadata_type!(Name, "Name of a plugin");
 metadata_type!(Author, "Author of a plugin");
-metadata_type!(Version, "Version of a plugin");

--- a/zeta/src/plugin.rs
+++ b/zeta/src/plugin.rs
@@ -3,18 +3,18 @@ use url::Url;
 
 pub use crate::context::Context;
 
-pub use zeta_plugin::{Author, Name, Plugin, Version};
+pub use zeta_plugin::{Author, Metadata, Name, Plugin};
 
 /// Common includes used in plugins.
 #[allow(unused)]
 mod prelude {
-    pub use super::{Author, Context, Name, Plugin, Version};
-    pub use crate::command::Command as ZetaCommand;
     pub use async_trait::async_trait;
     pub use irc::client::Client;
     pub use irc::proto::{Command, Message};
-    pub use irc::proto::{Command as IrcCommand, Message as IrcMessage};
     pub use zeta_plugin::Error as ZetaError;
+
+    pub use super::{Author, Context, Metadata, Name, Plugin};
+    pub use crate::command::Command as ZetaCommand;
 }
 
 /// Declares plugin modules and generates a registry helper to avoid boilerplate.

--- a/zeta/src/plugin/chaturbate.rs
+++ b/zeta/src/plugin/chaturbate.rs
@@ -66,16 +66,11 @@ impl Plugin<Context> for Chaturbate {
         Chaturbate::new()
     }
 
-    fn name() -> Name {
-        Name::from("chaturbate")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "chaturbate".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/choices.rs
+++ b/zeta/src/plugin/choices.rs
@@ -10,16 +10,11 @@ impl Plugin<Context> for Choices {
         Choices {}
     }
 
-    fn name() -> Name {
-        Name::from("choices")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "choices".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/dendanskeordbog.rs
+++ b/zeta/src/plugin/dendanskeordbog.rs
@@ -54,16 +54,11 @@ impl Plugin<Context> for DenDanskeOrdbog {
         DenDanskeOrdbog::new()
     }
 
-    fn name() -> Name {
-        Name::from("dendanskeordbog")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "dendanskeordbog".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/dig.rs
+++ b/zeta/src/plugin/dig.rs
@@ -82,16 +82,11 @@ impl Plugin<Context> for Dig {
         Dig { command, resolver }
     }
 
-    fn name() -> Name {
-        Name::from("dig")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "dig".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/geoip.rs
+++ b/zeta/src/plugin/geoip.rs
@@ -99,16 +99,11 @@ impl Plugin<Context> for GeoIp {
         }
     }
 
-    fn name() -> Name {
-        Name::from("geoip")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "geoip".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/github.rs
+++ b/zeta/src/plugin/github.rs
@@ -61,16 +61,11 @@ impl Plugin<Context> for GitHubPlugin {
         GitHubPlugin::new().expect("could not create github plugin")
     }
 
-    fn name() -> Name {
-        Name::from("github")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "github".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/google_images.rs
+++ b/zeta/src/plugin/google_images.rs
@@ -79,16 +79,11 @@ impl Plugin<Context> for GoogleImages {
         Self { client, command }
     }
 
-    fn name() -> Name {
-        Name::from("google_images")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> zeta_plugin::Metadata {
+        zeta_plugin::Metadata {
+            name: "google_images".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/health.rs
+++ b/zeta/src/plugin/health.rs
@@ -31,16 +31,11 @@ impl Plugin<Context> for Health {
         Health { command }
     }
 
-    fn name() -> Name {
-        Name::from("health")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "health".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/howlongtobeat.rs
+++ b/zeta/src/plugin/howlongtobeat.rs
@@ -212,16 +212,11 @@ impl Plugin<Context> for HowLongToBeat {
         }
     }
 
-    fn name() -> Name {
-        Name::from("hltb")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.2")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "hltb".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/isitopen.rs
+++ b/zeta/src/plugin/isitopen.rs
@@ -203,16 +203,11 @@ impl Plugin<Context> for IsItOpen {
         IsItOpen { client, api_key }
     }
 
-    fn name() -> Name {
-        Name::from("isitopen")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.2")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "isitopen".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/kagi.rs
+++ b/zeta/src/plugin/kagi.rs
@@ -59,16 +59,11 @@ impl Plugin<Context> for KagiPlugin {
         }
     }
 
-    fn name() -> Name {
-        Name::from("kagi")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "kagi".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/openweathermap.rs
+++ b/zeta/src/plugin/openweathermap.rs
@@ -121,16 +121,11 @@ impl Plugin<Context> for OpenWeatherMap {
         }
     }
 
-    fn name() -> Name {
-        Name::from("openweathermap")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("1.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "openweathermap".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/pornhub.rs
+++ b/zeta/src/plugin/pornhub.rs
@@ -138,16 +138,11 @@ impl Plugin<Context> for PornHub {
         PornHub { client }
     }
 
-    fn name() -> Name {
-        Name::from("pornhub")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "pornhub".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     // Handles incoming messages and processes any PornHub URLs found.

--- a/zeta/src/plugin/reddit.rs
+++ b/zeta/src/plugin/reddit.rs
@@ -175,16 +175,11 @@ impl Plugin<Context> for Reddit {
         }
     }
 
-    fn name() -> Name {
-        Name::from("reddit")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "reddit".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/rink.rs
+++ b/zeta/src/plugin/rink.rs
@@ -26,16 +26,11 @@ impl Plugin<Context> for Rink {
         }
     }
 
-    fn name() -> Name {
-        Name::from("choices")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "rink".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/rust_playground.rs
+++ b/zeta/src/plugin/rust_playground.rs
@@ -61,16 +61,11 @@ impl Plugin<Context> for RustPlayground {
         }
     }
 
-    fn name() -> Name {
-        Name::from("rust_playground")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("1.0")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "rust_playground".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/spotify.rs
+++ b/zeta/src/plugin/spotify.rs
@@ -132,16 +132,11 @@ impl Plugin<Context> for Spotify {
         }
     }
 
-    fn name() -> Name {
-        Name::from("spotify")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.3")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "spotify".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/string_utils.rs
+++ b/zeta/src/plugin/string_utils.rs
@@ -22,16 +22,11 @@ impl Plugin<Context> for StringUtils {
         StringUtils::new()
     }
 
-    fn name() -> Name {
-        Name::from("string_utils")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "string_utils".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/thingiverse.rs
+++ b/zeta/src/plugin/thingiverse.rs
@@ -83,16 +83,11 @@ impl Plugin<Context> for Thingiverse {
         }
     }
 
-    fn name() -> Name {
-        Name::from("thingiverse")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("1.0")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "thingiverse".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/tiktok.rs
+++ b/zeta/src/plugin/tiktok.rs
@@ -83,16 +83,11 @@ impl Plugin<Context> for Tiktok {
         Tiktok::new()
     }
 
-    fn name() -> Name {
-        Name::from("tiktok")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "tiktok".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/trustpilot.rs
+++ b/zeta/src/plugin/trustpilot.rs
@@ -83,16 +83,11 @@ impl Plugin<Context> for Trustpilot {
         }
     }
 
-    fn name() -> Name {
-        Name::from("trustpilot")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.2")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "trustpilot".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/tvmaze.rs
+++ b/zeta/src/plugin/tvmaze.rs
@@ -132,16 +132,11 @@ impl Plugin<Context> for Tvmaze {
         Tvmaze::new()
     }
 
-    fn name() -> Name {
-        Name::from("tvmaze")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "tvmaze".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/twitch.rs
+++ b/zeta/src/plugin/twitch.rs
@@ -124,16 +124,11 @@ impl Plugin<Context> for Twitch {
         }
     }
 
-    fn name() -> Name {
-        Name::from("twitch")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("1.0")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "twitch".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/urban_dictionary.rs
+++ b/zeta/src/plugin/urban_dictionary.rs
@@ -63,16 +63,11 @@ impl Plugin<Context> for UrbanDictionary {
         UrbanDictionary::new()
     }
 
-    fn name() -> Name {
-        Name::from("urban_dictionary")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "urban_dictionary".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(

--- a/zeta/src/plugin/youtube.rs
+++ b/zeta/src/plugin/youtube.rs
@@ -195,16 +195,11 @@ impl Plugin<Context> for YouTube {
         YouTube::with_config(api_key)
     }
 
-    fn name() -> Name {
-        Name::from("youtube")
-    }
-
-    fn author() -> Author {
-        Author::from("Mikkel Kroman <mk@maero.dk>")
-    }
-
-    fn version() -> Version {
-        Version::from("0.1")
+    fn metadata() -> Metadata {
+        Metadata {
+            name: "youtube".into(),
+            authors: vec!["Mikkel Kroman <mk@maero.dk>".into()],
+        }
     }
 
     async fn handle_message(


### PR DESCRIPTION
This PR removes the `Plugin<C>::{name,author,version}` functions and adds `Plugin<C>::metadata` which returns a `Metadata` struct with the plugin name and its authors.

Plugin versioning has been removed, as it doesn't make much sense when plugins are built with with the project.